### PR TITLE
Add mime types for .js and .css

### DIFF
--- a/web.config
+++ b/web.config
@@ -52,5 +52,9 @@
       See https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config for a full list of options
     -->
     <!--<iisnode watchedFiles="web.config;*.js"/>-->
+    <staticContent>
+        <mimeMap fileExtension=".js" mimeType="text/javascript" />
+        <mimeMap fileExtension=".css" mimeType="text/css" />
+    </staticContent>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
By default Azure served these as text/html, which broke api-docs.html in browsers where strict MIME type checking is enabled.